### PR TITLE
DICT_WORD_SIZE hinzugefügt

### DIFF
--- a/Lupus.inform/Metadata.iFiction
+++ b/Lupus.inform/Metadata.iFiction
@@ -17,7 +17,7 @@
         <releases>
             <attached>
                 <release>
-                    <releasedate>2018-05-13</releasedate>
+                    <releasedate>2018-05-17</releasedate>
                     <version>1</version>
                     <compiler>Inform 7</compiler>
                     <compilerversion>6M62</compilerversion>
@@ -27,10 +27,10 @@
         <colophon>
             <generator>Inform 7</generator>
             <generatorversion>6M62</generatorversion>
-            <originated>2018-05-13</originated>
+            <originated>2018-05-17</originated>
         </colophon>
         <glulx>
-            <serial>180513</serial>
+            <serial>180517</serial>
             <release>1</release>
             <compiler>Inform 7 build 6M62</compiler>
         </glulx>

--- a/Lupus.inform/Release.blurb
+++ b/Lupus.inform/Release.blurb
@@ -1,18 +1,18 @@
 ! Blurb file created by Inform build 6M62
 
-status "C:\Program Files (x86)\Inform 7\Internal\Miscellany\CblorbModel.html" "C:\Users\Karl\Google Drive\Siemens & Ostfalia\Semester & Aufgaben\SS18\CS-Kompetenzen\git repos\Lupus\Lupus.inform\Build\StatusCblorb.html"
+status "C:\Program Files (x86)\Inform 7\Internal\Miscellany\CblorbModel.html" "C:\Users\andre\Documents\GitHub\Lupus\Lupus.inform\Build\StatusCblorb.html"
 
 
 ! Identification
 
-project folder "C:\Users\Karl\Google Drive\Siemens & Ostfalia\Semester & Aufgaben\SS18\CS-Kompetenzen\git repos\Lupus\Lupus.inform"
-release to "C:\Users\Karl\Google Drive\Siemens & Ostfalia\Semester & Aufgaben\SS18\CS-Kompetenzen\git repos\Lupus\Lupus.materials\Release"
+project folder "C:\Users\andre\Documents\GitHub\Lupus\Lupus.inform"
+release to "C:\Users\andre\Documents\GitHub\Lupus\Lupus.materials\Release"
 
 ! Blorb instructions
 
 storyfile leafname "Lupus.gblorb"
-storyfile "C:\Users\Karl\Google Drive\Siemens & Ostfalia\Semester & Aufgaben\SS18\CS-Kompetenzen\git repos\Lupus\Lupus.inform\Build\output.ulx" include
-ifiction "C:\Users\Karl\Google Drive\Siemens & Ostfalia\Semester & Aufgaben\SS18\CS-Kompetenzen\git repos\Lupus\Lupus.inform\Metadata.iFiction" include
+storyfile "C:\Users\andre\Documents\GitHub\Lupus\Lupus.inform\Build\output.ulx" include
+ifiction "C:\Users\andre\Documents\GitHub\Lupus\Lupus.inform\Metadata.iFiction" include
 cover "C:\Program Files (x86)\Inform 7\Internal\Miscellany\Cover.jpg"
 picture 1 "C:\Program Files (x86)\Inform 7\Internal\Miscellany\Cover.jpg"
 

--- a/Lupus.inform/Source/story.ni
+++ b/Lupus.inform/Source/story.ni
@@ -2,6 +2,7 @@
 
 Use $MAX_STATIC_DATA of 100000000.
 Use MAX_STATIC_DATA of 100000000.
+Use DICT_WORD_SIZE of 100.
 
 
 You are in Andockbucht.


### PR DESCRIPTION
Use DICT_WORD_SIZE of 100.

Verlängert Variablenamen auf 100 Zeichen. So das Inform Lange Variabelnamen unterscheiden kann.